### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/app/backend/routes/storage.py
+++ b/app/backend/routes/storage.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, HTTPException
 import json
 from pathlib import Path
 from pydantic import BaseModel
+import os
 
 from app.backend.models.schemas import ErrorResponse
 
@@ -29,9 +30,15 @@ async def save_json_file(request: SaveJsonRequest):
         
         # Construct file path
         file_path = outputs_dir / request.filename
+
+        # Normalize and check that the file path is within outputs_dir
+        file_path_resolved = file_path.resolve()
+        outputs_dir_resolved = outputs_dir.resolve()
+        if not str(file_path_resolved).startswith(str(outputs_dir_resolved)):
+            raise HTTPException(status_code=400, detail="Invalid filename or directory traversal detected.")
         
         # Save JSON data to file
-        with open(file_path, 'w', encoding='utf-8') as f:
+        with open(file_path_resolved, 'w', encoding='utf-8') as f:
             json.dump(request.data, f, indent=2, ensure_ascii=False)
         
         return {


### PR DESCRIPTION
Potential fix for [https://github.com/I-AI-INTERGRATIONS/ai-hedge-fund/security/code-scanning/1](https://github.com/I-AI-INTERGRATIONS/ai-hedge-fund/security/code-scanning/1)

The best fix is to validate and sanitize the user-provided filename before using it to construct the file path. This can be done by:
- Normalizing the combined path (`os.path.normpath` or `Path.resolve()`) to eliminate `".."` or similar segments.
- Ensuring that the resulting path is within the intended `outputs` directory (i.e., the normalized path starts with the `outputs_dir` path).
- Additionally, using the `secure_filename` function from `werkzeug.utils` can further restrict filenames to safe values, but since the requirement is to allow subfolders, the normalization and containment check approach is the most flexible and secure.

**Specific changes:**
- Import `os` and `werkzeug.utils.secure_filename` (if desired for stricter filename sanitization).
- After constructing the full file path, normalize it (e.g., via `.resolve()` or `os.path.normpath`).
- Check that the resolved path starts with the `outputs_dir.resolve()` path.
- If the check fails, raise an HTTP 400 error with an appropriate message.
- Only proceed to write the file if the check passes.

Changes will be made in `app/backend/routes/storage.py`:
- Add imports if needed.
- Edit the `save_json_file` function to apply the validation logic before the `open()` call.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
